### PR TITLE
BUG: valid bbcode syntax breaks first list item

### DIFF
--- a/lib/tags/tags.rb
+++ b/lib/tags/tags.rb
@@ -21,12 +21,12 @@ module RubyBBCode
         :description => 'Center a text',
         :example => '[center]This is centered[/center].'},
       :ul => {
-        :html_open => '', :html_close => "\n",
+        :html_open => "\n", :html_close => "\n",
         :description => 'Unordered list',
         :example => '[ul][li]List item[/li][li]Another list item[/li][/ul].',
         :only_allow => [ :li ]},
       :ol => {
-        :html_open => '', :html_close => "\n",
+        :html_open => "\n", :html_close => "\n",
         :description => 'Ordered list',
         :example => '[ol][li]List item[/li][li]Another list item[/li][/ol].',
         :only_allow => [ :li ]},


### PR DESCRIPTION
This is valid bbcode:

```
Here's text.
[ol][li]this breaks it.[/li]
[li] this will be labelled number 1.[/li]
[/ol]
```
