### PR TITLE
default youtube tag urls to always be https

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The parser recognizes most "official tags":http://www.bbcode.org/reference.php a
 
 ## Example
 ```ruby
-"This is [b]bold[/b] and this is [i]italic[/i].".bbcode_to_html
+"This is [b]bold[/b] and this is [i]italic[/i].".bbcode_to_md
 ```
 =>
 ```markdown

--- a/lib/tags/tags.rb
+++ b/lib/tags/tags.rb
@@ -83,7 +83,7 @@ module RubyBBCode
         :tag_param => /(([a-z]+)|(#[0-9a-f]{6}))/i,
         :tag_param_tokens => [{:token => :color}]},
       :youtube => {
-        :html_open => 'http://www.youtube.com/watch?v=%between%', :html_close => '',
+        :html_open => 'https://www.youtube.com/watch?v=%between%', :html_close => '',
         :description => 'Youtube video',
         :example => '[youtube]E4Fbk52Mk1w[/youtube]',
         :only_allow => [],

--- a/test/current_test.rb
+++ b/test/current_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-require 'benchmark'
-
-
-
-class RubyBbcodeTest < Test::Unit::TestCase
-  
-end

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -80,17 +80,17 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
   end
 
   def test_youtube
-    assert_equal 'http://www.youtube.com/watch?v=E4Fbk52Mk1w', '[youtube]E4Fbk52Mk1w[/youtube]'.bbcode_to_md
+    assert_equal 'https://www.youtube.com/watch?v=E4Fbk52Mk1w', '[youtube]E4Fbk52Mk1w[/youtube]'.bbcode_to_md
   end
 
   def test_youtube_with_full_url
     full_url = "http://www.youtube.com/watch?feature=player_embedded&v=E4Fbk52Mk1w"
-    assert_equal "http://www.youtube.com/watch?v=E4Fbk52Mk1w", "[youtube]#{full_url}[/youtube]".bbcode_to_md
+    assert_equal "https://www.youtube.com/watch?v=E4Fbk52Mk1w", "[youtube]#{full_url}[/youtube]".bbcode_to_md
   end
 
   def test_youtube_with_url_shortener
     full_url = "http://www.youtu.be/cSohjlYQI2A"
-    assert_equal "http://www.youtube.com/watch?v=cSohjlYQI2A", "[youtube]#{full_url}[/youtube]".bbcode_to_md
+    assert_equal "https://www.youtube.com/watch?v=cSohjlYQI2A", "[youtube]#{full_url}[/youtube]".bbcode_to_md
   end
 
 
@@ -159,17 +159,17 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
     num = 2300  # increase this number if the test starts failing.  It's very near the tipping point
     openers = "[s]hi i'm" * num
     closers = "[/s]" * num
-    assert_raise( RuntimeError ) do
+    assert_raises( RuntimeError ) do
       (openers+closers).bbcode_to_md
     end
 
   end
 
   def test_mulit_tag
-    input1 = "[media]http://www.youtube.com/watch?v=cSohjlYQI2A[/media]"
+    input1 = "[media]https://www.youtube.com/watch?v=cSohjlYQI2A[/media]"
     input2 = "[media]http://vimeo.com/46141955[/media]"
 
-    output1 = "http://www.youtube.com/watch?v=cSohjlYQI2A"
+    output1 = "https://www.youtube.com/watch?v=cSohjlYQI2A"
     output2 = "http://vimeo.com/46141955"
 
     assert_equal output1, input1.bbcode_to_md
@@ -196,7 +196,5 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
     assert_equal "[Go to **Google**](http://google.com)", "[url=http://google.com]Go to [b]Google[/b][/url]".bbcode_to_md
     assert_equal "[**Google**](http://google.com)", "[url=http://google.com][color=#008000][b]Google[/b][/color][/url]".bbcode_to_md
   end
-
-
 
 end

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -1,6 +1,6 @@
-require 'test_helper'
+require_relative 'test_helper'
 
-class RubyBbcodeTest < Test::Unit::TestCase
+class RubyBbcodeTest < MiniTest::Unit::TestCase
 
   def test_multiline
     assert_equal "line1\nline2", "line1\nline2".bbcode_to_md

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'ruby-bbcode-to-md'
-require "test/unit"
+require 'minitest/autorun'
 
 # This hack allows us to make all the private methods of a class public.  
 class Class

--- a/test/unit/debugging_test.rb
+++ b/test/unit/debugging_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RubyBbcodeTest < Test::Unit::TestCase
+class RubyBbcodeTest < MiniTest::Unit::TestCase
   include ::RubyBBCode::Tags
   
   def test_bbtree_to_v

--- a/test/unit/tag_sifter_test.rb
+++ b/test/unit/tag_sifter_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class TagSifterTest < Test::Unit::TestCase
+class TagSifterTest < MiniTest::Unit::TestCase
   def test_youtube_parser
     url1 = "http://www.youtube.com/watch?v=E4Fbk52Mk1w"
     just_an_id = 'E4Fbk52Mk1w'


### PR DESCRIPTION
YouTube redirects everything to https anyway, so just make the default
output be https. This fixes the issue where an https link was changed to
http.

Fixes the bug I reported here https://meta.discourse.org/t/ruby-bbcode-to-markdown-removes-https/40425

I also made the tests working using MiniTest and fixed the README.md example.