### PR TITLE
convert [img] into markdown image, add [list], fix [ul][ol] whitespace, add [code] tag

### DIFF
--- a/lib/ruby-bbcode-to-md/tag_collection.rb
+++ b/lib/ruby-bbcode-to-md/tag_collection.rb
@@ -19,6 +19,10 @@ module RubyBBCode
             t.remove_unused_tokens!
           end
 
+          if node.allow_tag_param_children?
+            t.substitute_children_html_params(children_html)
+          end
+
           html_string += t.opening_html
 
           html_string += children_html if children_html && !node.definition[:require_between]
@@ -33,8 +37,6 @@ module RubyBBCode
 
       html_string
     end
-
-
 
     # This class is designed to help us build up the HTML data.  It starts out as a template such as...
     #   @opening_html = '<a href="%url%">%between%'
@@ -110,8 +112,16 @@ module RubyBBCode
         end
       end
 
-      private
+      def substitute_children_html_params(children_html)
+        return if children_html.nil?
+        @tag_definition[:tag_param_tokens].each do |token|
+          param = (@node[:params] && @node[:params][:tag_param]) || nil
+          sub = @tag_definition[:tag_param_lambda][param]
+          children_html.gsub!("%parent_#{token[:token]}%", sub)
+        end
+      end
 
+      private
       def between_text_goes_into_html_output_as_param?
         @tag_definition[:require_between]
       end

--- a/lib/ruby-bbcode-to-md/tag_node.rb
+++ b/lib/ruby-bbcode-to-md/tag_node.rb
@@ -19,7 +19,6 @@ module RubyBBCode
       @element[key] = value
     end
 
-    # Debugging/ visualization purposes
     def type
       return :tag if @element[:is_tag]
       return :text if !@element[:is_tag]
@@ -46,6 +45,10 @@ module RubyBBCode
 
     def allow_tag_param?
       definition[:allow_tag_param]
+    end
+
+    def allow_tag_param_children?
+      definition[:allow_tag_param_children]
     end
 
     # shows the tag definition for this TagNode as defined in tags.rb

--- a/lib/ruby-bbcode-to-md/tag_sifter.rb
+++ b/lib/ruby-bbcode-to-md/tag_sifter.rb
@@ -8,7 +8,7 @@ module RubyBBCode
       @text = escape_html ? text_to_parse.gsub('<', '&lt;').gsub('>', '&gt;').gsub('"', "&quot;") : text_to_parse
 
       @dictionary = dictionary # the dictionary for all the defined tags in tags.rb
-      @bbtree = BBTree.new({:nodes => TagCollection.new}, dictionary)
+      @bbtree = BBTree.new(dictionary)
       @ti = nil
       @errors = false
     end
@@ -19,7 +19,7 @@ module RubyBBCode
 
 
     def process_text
-      regex_string = '((\[ (\/)? (\w+) ((=[^\[\]]+) | (\s\w+=\w+)* | ([^\]]*))? \]) | ([^\[]+))'
+      regex_string = '((\[ (\/)? ([\w\*]+) ((=[^\[\]]+) | (\s\w+=\w+)* | ([^\]]*))? \]) | ([^\[]+))'
       @text.scan(/#{regex_string}/ix) do |tag_info|
         @ti = TagInfo.new(tag_info, @dictionary)
 
@@ -40,6 +40,11 @@ module RubyBBCode
           element = {:is_tag => false, :text => @ti.text }
           if within_open_tag?
             tag = @bbtree.current_node.definition
+
+            if tag[:only_allow] and !tag[:only_allow].empty?
+              next
+            end
+
             if tag[:require_between]
               @bbtree.current_node[:between] = get_formatted_element_params
               if candidate_for_using_between_as_param?

--- a/lib/tags/tags.rb
+++ b/lib/tags/tags.rb
@@ -105,6 +105,12 @@ module RubyBBCode
         :allow_tag_param => true, :allow_tag_param_between => false,
         :tag_param => /(([a-z]+)|(#[0-9a-f]{6}))/i,
         :tag_param_tokens => [{:token => :color}]},
+      :code => {
+        :html_open => '```\n%between%\n```', :html_close => '',
+        :description => 'preformatted code block',
+        :example => '[code] x = x + 1;[/code]',
+        :only_allow => [],
+        :require_between => true},
       :youtube => {
         :html_open => 'https://www.youtube.com/watch?v=%between%', :html_close => '',
         :description => 'Youtube video',

--- a/lib/tags/tags.rb
+++ b/lib/tags/tags.rb
@@ -20,6 +20,29 @@ module RubyBBCode
         :html_open => '', :html_close => '',
         :description => 'Center a text',
         :example => '[center]This is centered[/center].'},
+      :list => {
+        :html_open => "\n", :html_close => "\n",
+        :description => 'Unordered list',
+        :example => '[list][*]List item[/*][*]Another list item[/*][/list].',
+        :allow_tag_param => true, :allow_tag_param_children => true,
+        :tag_param => /(\w*)/,
+        :tag_param_tokens => [{:token => :order}],
+        :tag_param_lambda => ->(param) {
+          if param == "1"
+            "1."
+          else
+            "-"
+          end
+        },
+        :only_allow => [ :* ]},
+      :* => {
+        :html_open => {
+          :list => '  %parent_order% '
+        },
+        :html_close => "\n",
+        :description => 'List item',
+        :example => '[list][*]List item[/*][*]Another list item[/*][/list].',
+        :only_in => [ :list ]},
       :ul => {
         :html_open => "\n", :html_close => "\n",
         :description => 'Unordered list',

--- a/lib/tags/tags.rb
+++ b/lib/tags/tags.rb
@@ -106,7 +106,7 @@ module RubyBBCode
         :tag_param => /(([a-z]+)|(#[0-9a-f]{6}))/i,
         :tag_param_tokens => [{:token => :color}]},
       :code => {
-        :html_open => '```\n%between%\n```', :html_close => '',
+        :html_open => "```\n%between%\n```", :html_close => '',
         :description => 'preformatted code block',
         :example => '[code] x = x + 1;[/code]',
         :only_allow => [],

--- a/lib/tags/tags.rb
+++ b/lib/tags/tags.rb
@@ -40,7 +40,7 @@ module RubyBBCode
         :example => '[ul][li]List item[/li][li]Another list item[/li][/ul].',
         :only_in => [ :ul, :ol ]},
       :img => {
-        :html_open => '%between%', :html_close => '',
+        :html_open => '![](%between%)', :html_close => '',
         :description => 'Image',
         :example => '[img]http://www.google.com/intl/en_ALL/images/logo.gif[/img].',
         :only_allow => [],

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -208,4 +208,8 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
     assert_equal "[**Google**](http://google.com)", "[url=http://google.com][color=#008000][b]Google[/b][/color][/url]".bbcode_to_md
   end
 
+  def test_code
+    assert_equal '```\nx = x+1;\n```', '[code]x = x+1;[/code]'.bbcode_to_md
+  end
+
 end

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -73,9 +73,9 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
   end
 
   def test_image
-    assert_equal 'http://www.ruby-lang.org/images/logo.gif',
+    assert_equal '![](http://www.ruby-lang.org/images/logo.gif)',
                    '[img]http://www.ruby-lang.org/images/logo.gif[/img]'.bbcode_to_md
-    assert_equal 'http://www.ruby-lang.org/images/logo.gif',
+    assert_equal '![](http://www.ruby-lang.org/images/logo.gif)',
                    '[img=95x96]http://www.ruby-lang.org/images/logo.gif[/img]'.bbcode_to_md
   end
 

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -8,6 +8,8 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
     assert_equal "\n  - item 1\n  - item 2\n\n",
                  "[list][*]item 1[/*][*]item 2[/*][/list]".bbcode_to_md
     assert_equal "\n  - item 1\n  - item 2\n\n",
+                 "[list=a][*]item 1[/*][*]item 2[/*][/list]".bbcode_to_md
+    assert_equal "\n  - item 1\n  - item 2\n\n",
                  "[list]\n[*]item 1[/*]\n[*]item 2[/*]\n[/list]".bbcode_to_md
   end
 

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -209,7 +209,7 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
   end
 
   def test_code
-    assert_equal '```\nx = x+1;\n```', '[code]x = x+1;[/code]'.bbcode_to_md
+    assert_equal "```\nx = x+1;\n```", '[code]x = x+1;[/code]'.bbcode_to_md
   end
 
 end

--- a/test/ruby_bbcode_test.rb
+++ b/test/ruby_bbcode_test.rb
@@ -2,6 +2,15 @@ require_relative 'test_helper'
 
 class RubyBbcodeTest < MiniTest::Unit::TestCase
 
+  def test_list_tag
+    assert_equal "\n  1. item 1\n  1. item 2\n\n",
+                 "[list=1]\n[*]item 1[/*]\n[*]item 2[/*]\n[/list]".bbcode_to_md
+    assert_equal "\n  - item 1\n  - item 2\n\n",
+                 "[list][*]item 1[/*][*]item 2[/*][/list]".bbcode_to_md
+    assert_equal "\n  - item 1\n  - item 2\n\n",
+                 "[list]\n[*]item 1[/*]\n[*]item 2[/*]\n[/list]".bbcode_to_md
+  end
+
   def test_multiline
     assert_equal "line1\nline2", "line1\nline2".bbcode_to_md
     assert_equal "line1\nline2", "line1\r\nline2".bbcode_to_md
@@ -37,6 +46,7 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
 
   def test_ordered_list
     assert_equal "\n  1. item 1\n  1. item 2\n\n", '[ol][li]item 1[/li][li]item 2[/li][/ol]'.bbcode_to_md
+#    assert_equal "\n  1. item 1\n  1. item 2\n\n", "[ol]\n[li]item 1[/li]\n[li]item 2[/li]\n[/ol]".bbcode_to_md
   end
 
   def test_unordered_list
@@ -49,9 +59,8 @@ class RubyBbcodeTest < MiniTest::Unit::TestCase
   end
 
   def test_whitespace_in_only_allowed_tags
-    assert_equal "\n\n  1. item 1\n\n  1. item 2\n\n\n", "[ol]\n[li]item 1[/li]\n[li]item 2[/li]\n[/ol]".bbcode_to_md
-    assert_equal "\n   1. item 1\n    1. item 2\n\n", "[ol] [li]item 1[/li]  [li]item 2[/li][/ol]".bbcode_to_md
-
+    assert_equal "\n  1. item 1\n  1. item 2\n\n", "[ol]\n[li]item 1[/li]\n[li]item 2[/li]\n[/ol]".bbcode_to_md
+    assert_equal "\n  1. item 1\n  1.  item 2\n\n", "[ol] [li]item 1[/li]  [li] item 2[/li][/ol]".bbcode_to_md
   end
 
   def test_quote

--- a/test/unit/tag_sifter_test.rb
+++ b/test/unit/tag_sifter_test.rb
@@ -8,44 +8,41 @@ class TagSifterTest < MiniTest::Unit::TestCase
     url_without_www = "youtube.com/watch?v=E4Fbk52Mk1w"
     url_with_feature = "http://www.youtube.com/watch?feature=player_embedded&v=E4Fbk52Mk1w"
     mock_regex_matches = [/youtube.com.*[v]=([^&]*)/, /youtu.be\/([^&]*)/, /y2u.be\/([^&]*)/]
-    
+
     expected_output = 'E4Fbk52Mk1w'
-    
+
     RubyBBCode::TagSifter.publicize_methods do
       ts = RubyBBCode::TagSifter.new "", ""
-      assert_equal expected_output, 
+      assert_equal expected_output,
                      ts.conduct_special_formatting(url1, mock_regex_matches)
-      
-      assert_equal expected_output, 
+
+      assert_equal expected_output,
                    ts.conduct_special_formatting(just_an_id, mock_regex_matches)
-                   
-      assert_equal expected_output, 
+
+      assert_equal expected_output,
                      ts.conduct_special_formatting(url_without_http, mock_regex_matches)
-                     
-      assert_equal expected_output, 
+
+      assert_equal expected_output,
                      ts.conduct_special_formatting(url_without_www, mock_regex_matches)
-                     
-      assert_equal expected_output, 
+
+      assert_equal expected_output,
                      ts.conduct_special_formatting(url_with_feature, mock_regex_matches)
     end
-    
+
   end
 
-	# I think the answer to this is creating a new tag named [youtube]
-	# but that captures specifically the .be or .com and treats them differently...
-	def test_youtubes_via_there_url_shortener
-		url_from_shortener = "http://youtu.be/E4Fbk52Mk1w"
-		directory_format = "http://youtube.googleapis.com/v/E4Fbk52Mk1w"
+  # I think the answer to this is creating a new tag named [youtube]
+  # but that captures specifically the .be or .com and treats them differently...
+  def test_youtubes_via_there_url_shortener
+    url_from_shortener = "http://youtu.be/E4Fbk52Mk1w"
+    directory_format = "http://youtube.googleapis.com/v/E4Fbk52Mk1w"
     expected_output = 'E4Fbk52Mk1w'
     mock_regex_matches = [/youtube.com.*[v]=([^&]*)/, /youtu.be\/([^&]*)/, /y2u.be\/([^&]*)/]
 
-    
     RubyBBCode::TagSifter.publicize_methods do
       ts = RubyBBCode::TagSifter.new "", ""
-      
-      
-			assert_equal expected_output, 
-				             ts.conduct_special_formatting(url_from_shortener, mock_regex_matches)   # this test is now hopelessly broken because generating an ID from a link requires that @bbtree.current_node.definition be properly populated with regex matches...
-		end
-	end
+      assert_equal expected_output,
+                   ts.conduct_special_formatting(url_from_shortener, mock_regex_matches)   # this test is now hopelessly broken because generating an ID from a link requires that @bbtree.current_node.definition be properly populated with regex matches...
+    end
+  end
 end


### PR DESCRIPTION
Before, it was just outputting the image URL. Now, it makes it into the
markdown format by starting the link with "!"

Also, added support for [list] from phpbb and remove whitespace preservation inside ul, ol, list
